### PR TITLE
Move the countdown calculation into a function

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,29 +13,33 @@
 // Set the date we're counting down to
 var countDownDate = new Date("Dec 31, 2022 11:59:59").getTime();
 
+function updateCountdown() {
+	// Get today's date and time
+	var now = new Date().getTime();
+
+	// Find the distance between now and the count down date
+	var distance = countDownDate - now;
+
+	// Time calculations for days, hours, minutes and seconds
+	var days = Math.floor(distance / (1000 * 60 * 60 * 24));
+	var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+	var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+	var seconds = Math.floor((distance % (1000 * 60)) / 1000);
+
+	// Display the result in the element with id="demo"
+	document.getElementById("demo").innerHTML = days + " days, " + hours + " hours "
+	+ minutes + " minutes, and " + seconds + " seconds.";
+
+	// If the count down is finished, write some text
+	if (distance < 0) {
+	clearInterval(x);
+	document.getElementById("demo").innerHTML = "EXPIRED";
+	}
+}
+
+// Update the count down initially (avoids waiting a single second before first update)
+updateCountdown()
+
 // Update the count down every 1 second
-var x = setInterval(function() {
-
-  // Get today's date and time
-  var now = new Date().getTime();
-
-  // Find the distance between now and the count down date
-  var distance = countDownDate - now;
-
-  // Time calculations for days, hours, minutes and seconds
-  var days = Math.floor(distance / (1000 * 60 * 60 * 24));
-  var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-  var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-  var seconds = Math.floor((distance % (1000 * 60)) / 1000);
-
-  // Display the result in the element with id="demo"
-  document.getElementById("demo").innerHTML = days + " days, " + hours + " hours "
-  + minutes + " minutes, and " + seconds + " seconds.";
-
-  // If the count down is finished, write some text
-  if (distance < 0) {
-    clearInterval(x);
-    document.getElementById("demo").innerHTML = "EXPIRED";
-  }
-}, 1000);
+var x = setInterval(updateCountdown, 1000);
 </script>


### PR DESCRIPTION
This allows for the 1 second wait that was required before to still show the count down as the interval won't run for 1 second but the function can be called initially to get around that issue.

We can't allow people to wait to see how long until Bonelab releases and they can scream "What up son" at null bodies and skeletons 😠